### PR TITLE
Pass selected sku id in query string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Pass selected skuId in query string.
+
 ## [0.2.1] - 2021-01-13
 
 ### Fixed

--- a/react/LinkSeller.tsx
+++ b/react/LinkSeller.tsx
@@ -27,6 +27,7 @@ function LinkSeller() {
         className={`${handles.linkSeller}`}
         page="store.sellers"
         params={{ slug: product?.linkText }}
+        query={selectedItem ? `skuId=${selectedItem.itemId}` : ''}
       >
         <p className={`${handles.linkSellerText} pr6`}>
           <FormattedMessage


### PR DESCRIPTION
#### What does this PR do? \*

Fix seller selection page passing the selected skuId in the query string.

Issue: https://vtex.slack.com/archives/C9P4RMW6Q/p1610717683010500?thread_ts=1610717667.010200&cid=C9P4RMW6Q


#### How to test it? \*

https://qaenv--n95.myvtex.com/test-product-10970/p?skuId=1096224

#### Describe alternatives you've considered, if any. \*

n/a

#### Related to / Depends on \*

<!--- Optional -->
