### PR TITLE
Remove unavailable sellers from seller list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Remove unavailable sellers from the list of sellers.
 
 ## [0.2.2] - 2021-01-15
 

--- a/react/LinkSeller.tsx
+++ b/react/LinkSeller.tsx
@@ -15,7 +15,11 @@ function LinkSeller() {
   const { product, selectedItem } = useProduct() ?? {}
   const handles = useCssHandles(LINK_SELLER_HANDLES)
 
-  if (!selectedItem || selectedItem.sellers.length <= 1) {
+  const availableSellers = selectedItem?.sellers.filter(
+    (seller) => seller.commertialOffer.AvailableQuantity > 0
+  )
+
+  if (!selectedItem || !availableSellers || availableSellers.length <= 1) {
     return null
   }
 
@@ -33,7 +37,7 @@ function LinkSeller() {
           <FormattedMessage
             id="store/seller-link.linkText"
             values={{
-              number: selectedItem?.sellers.length,
+              number: availableSellers.length,
             }}
           />
         </p>

--- a/react/SellerTable.tsx
+++ b/react/SellerTable.tsx
@@ -25,7 +25,11 @@ function SellerTable({
 
   const sellerContext = useMemo(
     () => ({
-      sellerList: selectedItem ? selectedItem.sellers : null,
+      sellerList: selectedItem
+        ? selectedItem.sellers.filter(
+            (seller) => seller.commertialOffer.AvailableQuantity > 0
+          )
+        : null,
       shippingQuotes,
       setShippingQuotes,
       limitShownShippingInformation: limitShownShippingInformation || 3,


### PR DESCRIPTION
#### What does this PR do? \*

Remove sellers that are not available:

![image](https://user-images.githubusercontent.com/284515/106299779-5f340c00-6234-11eb-87ce-7e58453e3aaf.png)

#### How to test it? \*

See thread on how to login: https://vtex.slack.com/archives/C9P4RMW6Q/p1611936262101300?thread_ts=1611935898.099800&cid=C9P4RMW6Q

"View X more sellers" is not shown because there's just one seller available:
https://brenovtex--n95.myvtex.com/powecom-kn95-respirators-bag-of-10/p?skuId=1096240

Seller table only shows the seller that have available quantity:
https://brenovtex--n95.myvtex.com/sellers/powecom-kn95-respirators-bag-of-10?skuId=1096240

Before | After
---|---
![image](https://user-images.githubusercontent.com/284515/106299935-986c7c00-6234-11eb-81fb-f3e0d1afd390.png) | ![image](https://user-images.githubusercontent.com/284515/106299910-90144100-6234-11eb-8d6a-e77501aaac5b.png)


#### Describe alternatives you've considered, if any. \*

n/a

#### Related to / Depends on \*

<!--- Optional -->
