### PR TITLE
add site editor property to edit seller link text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Add site editor property to edit seller link text
+
 ## [0.2.3] - 2021-01-29
 ### Fixed
 - Remove unavailable sellers from the list of sellers.

--- a/docs/README.md
+++ b/docs/README.md
@@ -135,6 +135,17 @@ Behind the scenes, the Seller Selector page uses the following default implement
 |`buy-button`  | Default buy button, will be used if nothing is provided in the blocks section of `seller-add-to-cart`|
 |`add-to-cart-button`  | Buy button to use with Minicart.V2 and GoCommerce Stores |
 
+#### `link-seller` props
+
+| Prop name              | Type      | Description                                                                                                                                                                                                                                     | Default value |
+| ---------------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `message`     | `string`  | Text displayed on link counter | `store/seller-link.linkText`|
+
+| Message variables | Type | Description | Example |
+| --- | --- | --- | --- |
+| `sellerQuantity` | `number` | Number of sellers sell this product | <code>View {**sellerQuantity**, plural, one {1 more seller} other {# more sellers}}</code> |
+
+This block uses the [ICU Message Format](https://format-message.github.io/icu-message-format-for-translators/), making it possible to fully edit the text message and variables displayed on block.
 
 #### `seller-table` props
 

--- a/manifest.json
+++ b/manifest.json
@@ -11,6 +11,7 @@
     "store": "0.x"
   },
   "dependencies": {
+    "vtex.native-types": "0.x",
     "vtex.styleguide": "9.x",
     "vtex.css-handles": "0.x",
     "vtex.product-context": "0.x",
@@ -24,9 +25,7 @@
     "vtex.address-form": "4.x",
     "vtex.add-to-cart-button": "0.x"
   },
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "policies": [],
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/messages/context.json
+++ b/messages/context.json
@@ -1,7 +1,7 @@
 {
   "store/seller-list.pending": "Type postal code to calculate",
   "store/seller-list.shipping-label": "Calculate shipping",
-  "store/seller-link.linkText": "View {number, plural, one {1 more seller} other {# more sellers}}",
+  "store/seller-link.linkText": "View {sellerQuantity, plural, one {1 more seller} other {# more sellers}}",
   "store/seller-list.shipping-estimate": "{name} {price} {estimate}",
   "admin/editor.seller-selector.title": "Seller Selector",
   "admin/editor.seller-selector.head-cell": "Header Cell",
@@ -9,5 +9,8 @@
   "admin/editor.seller-selector.limitShippingInformation-title": "How many shipping quotes should be displayed?",
   "admin/editor.seller-selector.limitShippingInformation-description": "Configure how many shipping quotes should be displayed, this configuration will be applied to all sellers in this page",
   "admin/editor.seller-selector.add-to-cart": "Add To Cart",
-  "admin/editor.seller-selector.oneClickBuy-title": "Redirect to checkout"
+  "admin/editor.seller-selector.oneClickBuy-title": "Redirect to checkout",
+  "admin/editor.seller-link.title": "Seller Link",
+  "admin/editor.seller-link.textLinkTitle": "Link text",
+  "admin/editor.seller-link.textLinkDescription": "Values available for interpolation: '{sellerQuantity}'"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,7 +1,7 @@
 {
   "store/seller-list.pending": "Type postal code to calculate",
   "store/seller-list.shipping-label": "Calculate shipping",
-  "store/seller-link.linkText": "View {number, plural, one {1 more seller} other {# more sellers}}",
+  "store/seller-link.linkText": "View {sellerQuantity, plural, one {1 more seller} other {# more sellers}}",
   "store/seller-list.shipping-estimate": "{name} {price} {estimate}",
   "admin/editor.seller-selector.title": "Seller Selector",
   "admin/editor.seller-selector.head-cell": "Header Cell",
@@ -9,5 +9,8 @@
   "admin/editor.seller-selector.limitShippingInformation-title": "How many shipping quotes should be displayed?",
   "admin/editor.seller-selector.limitShippingInformation-description": "Configure how many shipping quotes should be displayed, this configuration will be applied to all sellers in this page",
   "admin/editor.seller-selector.add-to-cart": "Add To Cart",
-  "admin/editor.seller-selector.oneClickBuy-title": "Redirect to checkout"
+  "admin/editor.seller-selector.oneClickBuy-title": "Redirect to checkout",
+  "admin/editor.seller-link.title": "Seller Link",
+  "admin/editor.seller-link.textLinkTitle": "Link text",
+  "admin/editor.seller-link.textLinkDescription": "Values available for interpolation: '{sellerQuantity}'"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,7 +1,7 @@
 {
   "store/seller-list.pending": "Escriba el código postal para calcular",
   "store/seller-list.shipping-label": "Calcular el flete",
-  "store/seller-link.linkText": "Verifique {number, plural, one {otro vendedor} other {# otros vendedores}}",
+  "store/seller-link.linkText": "Verifique {sellerQuantity, plural, one {otro vendedor} other {# otros vendedores}}",
   "store/seller-list.shipping-estimate": "{name} {price} {estimate}",
   "admin/editor.seller-selector.title": "Selector de vendedor",
   "admin/editor.seller-selector.head-cell": "Celda de encabezado",
@@ -9,5 +9,8 @@
   "admin/editor.seller-selector.limitShippingInformation-title": "¿Cuántas cotizaciones de envío se deben mostrar?",
   "admin/editor.seller-selector.limitShippingInformation-description": "Configure cuántas cotizaciones de envío deben mostrarse, esta configuración se aplicará a todos los vendedores en esta página",
   "admin/editor.seller-selector.add-to-cart": "Añadir al carrito",
-  "admin/editor.seller-selector.oneClickBuy-title": "Redireccionar a pagar"
+  "admin/editor.seller-selector.oneClickBuy-title": "Redireccionar a pagar",
+  "admin/editor.seller-link.title": "Enlace del vendedor",
+  "admin/editor.seller-link.textLinkTitle": "Texto del enlace",
+  "admin/editor.seller-link.textLinkDescription": "Valores disponibles para interpolación: '{sellerQuantity}'"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1,7 +1,7 @@
 {
   "store/seller-list.pending": "Digite o CEP para calcular",
   "store/seller-list.shipping-label": "Calcular o frete",
-  "store/seller-link.linkText": "Verificar {number, plural, one {uma outra loja} other {# outras lojas}}",
+  "store/seller-link.linkText": "Verificar {sellerQuantity, plural, one {uma outra loja} other {# outras lojas}}",
   "store/seller-list.shipping-estimate": "{name} {price} {estimate}",
   "admin/editor.seller-selector.title": "Seletor de vendedor",
   "admin/editor.seller-selector.head-cell": "Cabeçalho",
@@ -9,5 +9,8 @@
   "admin/editor.seller-selector.limitShippingInformation-title": "Quantas cotações de frete devem aparecer?",
   "admin/editor.seller-selector.limitShippingInformation-description": "Configure quantas informações de frete devem ser exibidas na tela simultaneamente, esta configuração será aplicada a todos os vendedores nessa pagina",
   "admin/editor.seller-selector.add-to-cart": "Adicionar Ao Carrinho",
-  "admin/editor.seller-selector.oneClickBuy-title": "Redirect to checkout"
+  "admin/editor.seller-selector.oneClickBuy-title": "Redirect to checkout",
+  "admin/editor.seller-link.title": "Link de vendedor",
+  "admin/editor.seller-link.textLinkTitle": "Texto do link",
+  "admin/editor.seller-link.textLinkDescription": "Valores disponíveis para interpolação: '{sellerQuantity}'"
 }

--- a/react/LinkSeller.tsx
+++ b/react/LinkSeller.tsx
@@ -2,7 +2,8 @@ import React from 'react'
 import { Link } from 'vtex.render-runtime'
 import { useProduct } from 'vtex.product-context'
 import { useCssHandles } from 'vtex.css-handles'
-import { FormattedMessage } from 'react-intl'
+import { IOMessage } from 'vtex.native-types'
+import { defineMessages } from 'react-intl'
 
 const LINK_SELLER_HANDLES = [
   'linkSellerContainer',
@@ -11,7 +12,11 @@ const LINK_SELLER_HANDLES = [
   'linkSellerNumber',
 ] as const
 
-function LinkSeller() {
+interface Props {
+  message?: string
+}
+
+function LinkSeller({ message }: Props) {
   const { product, selectedItem } = useProduct() ?? {}
   const handles = useCssHandles(LINK_SELLER_HANDLES)
 
@@ -34,10 +39,10 @@ function LinkSeller() {
         query={selectedItem ? `skuId=${selectedItem.itemId}` : ''}
       >
         <p className={`${handles.linkSellerText} pr6`}>
-          <FormattedMessage
-            id="store/seller-link.linkText"
+          <IOMessage
+            id={message}
             values={{
-              number: availableSellers.length,
+              sellerQuantity: availableSellers.length,
             }}
           />
         </p>
@@ -46,9 +51,14 @@ function LinkSeller() {
   )
 }
 
+const messages = defineMessages({
+  title: {
+    id: 'admin/editor.seller-link.title',
+  },
+})
+
 LinkSeller.schema = {
-  title: 'editor.countdown.title',
-  description: 'editor.countdown.description',
+  title: messages.title.id,
 }
 
 export default LinkSeller

--- a/react/package.json
+++ b/react/package.json
@@ -17,6 +17,7 @@
     "@vtex/tsconfig": "^0.2.0",
     "graphql": "^14.6.0",
     "typescript": "3.9.7",
+    "vtex.native-types": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.5/public/@types/vtex.native-types",
     "vtex.add-to-cart-button": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.add-to-cart-button@0.21.1/public/@types/vtex.add-to-cart-button",
     "vtex.address-form": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.address-form@4.6.3/public/_types/react",
     "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5000,6 +5000,10 @@ verror@1.10.0:
   version "0.3.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.format-currency@0.3.0/public/@types/vtex.format-currency#1cb7360452552301237c16d32037bbac61798f20"
 
+"vtex.native-types@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.5/public/@types/vtex.native-types":
+  version "0.7.5"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.5/public/@types/vtex.native-types#52d8c0b675fcdf2b6b1ca93f6a99a630519f618f"
+
 "vtex.product-context@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.9.7/public/@types/vtex.product-context":
   version "0.9.7"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.9.7/public/@types/vtex.product-context#4024c589f1ba318e92219a88bf18b4e3774dc85c"

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -1,0 +1,15 @@
+{
+  "definitions": {
+    "LinkSeller": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "title": "admin/editor.seller-link.textLinkTitle",
+          "description": "admin/editor.seller-link.textLinkDescription",
+          "$ref": "app:vtex.native-types#/definitions/text",
+          "default": "store/seller-link.linkText"
+        }
+      }
+    }
+  }
+}

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -1,17 +1,16 @@
 {
   "store.sellers": {
-    "around": [
-      "productWrapper"
-    ],
+    "around": ["productWrapper"],
     "context": "vtex.store/ProductContext"
   },
   "store.product.sellertest": {
-    "allowed": [
-      "link-seller"
-    ]
+    "allowed": ["link-seller"]
   },
   "link-seller": {
-    "component": "LinkSeller"
+    "component": "LinkSeller",
+    "content": {
+      "$ref": "app:vtex.seller-selector#/definitions/LinkSeller"
+    }
   },
   "seller-table": {
     "component": "SellerTable",
@@ -50,10 +49,7 @@
   },
   "seller-add-to-cart": {
     "component": "SellerAddToCart",
-    "allowed": [
-      "add-to-cart-button",
-      "buy-button"
-    ]
+    "allowed": ["add-to-cart-button", "buy-button"]
   },
   "seller-simulate-shipping": {
     "component": "SimulateShipping"


### PR DESCRIPTION
#### What does this PR do? \*
Add site editor property to edit seller link text
#### How to test it? \*
https://wagnerlduarte--pedrocruzio.myvtex.com/admin/cms/site-editor/luxury-purple-ballon/p?__device=desktop

## Before, with static text:
![image](https://user-images.githubusercontent.com/17439470/133321270-cceaaff8-1190-4716-a6d9-03008cc10652.png)

## After, with dynamic text:
![image](https://user-images.githubusercontent.com/17439470/133321393-7711bf07-d8e5-4f86-9236-a42c14404273.png)
